### PR TITLE
Handle loading status globally

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "graphql": "^15.3.0",
     "node-sass": "^4.14.1",
     "react": "^16.13.1",
+    "react-apollo-network-status": "^5.0.1",
     "react-dom": "^16.13.1",
     "react-helmet": "^6.1.0",
     "react-image-crop": "^8.6.5",

--- a/src/Apollo.tsx
+++ b/src/Apollo.tsx
@@ -10,6 +10,7 @@ import {
 import { setContext } from '@apollo/client/link/context'
 import fetch from 'cross-fetch'
 import * as React from 'react'
+import { createNetworkStatusNotifier } from 'react-apollo-network-status'
 import { isTokenRequired } from './graphql/tokenRequiredOperations'
 import { AuthService } from './services/AuthService'
 import { AWS_APPSYNC_API_KEY, AWS_APPSYNC_GRAPHQL_ENDPOINT } from './utils/env'
@@ -18,6 +19,8 @@ const httpLink = createHttpLink({
   uri: AWS_APPSYNC_GRAPHQL_ENDPOINT,
   fetch,
 })
+
+const {link, useApolloNetworkStatus} = createNetworkStatusNotifier();
 
 type OperationType = 'query' | 'mutation'
 const useToken = (operation: GraphQLRequest): boolean => {
@@ -44,7 +47,7 @@ const authLink = setContext(async (operation, { headers }) => {
   }
 })
 const client = new ApolloClient({
-  link: ApolloLink.from([authLink, httpLink]),
+  link: link.concat(ApolloLink.from([authLink, httpLink])),
   cache: new InMemoryCache(),
   defaultOptions: {
     watchQuery: {
@@ -61,3 +64,5 @@ export const WithApolloProvider = (Component: React.FC) => () => (
     <Component />
   </ApolloProvider>
 )
+
+export { useApolloNetworkStatus }

--- a/src/components/Loading/index.tsx
+++ b/src/components/Loading/index.tsx
@@ -1,0 +1,51 @@
+import { faSpinner } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import * as React from 'react'
+import styled, { keyframes } from 'styled-components'
+
+const LoadingMask = styled.div`
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  opacity: 0.5;
+  background: #000;
+`
+
+const rotate = keyframes`
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+`
+
+const Spinner = styled.div`
+  animation: ${rotate} 2s linear infinite;
+`
+
+interface LoadingProps {
+  loading: boolean
+}
+
+const Loading: React.FC<LoadingProps> = ({ children, loading }) => {
+  if (loading) {
+    return (
+      <LoadingMask>
+        <Spinner>
+          <FontAwesomeIcon icon={faSpinner} size="lg" color="white" />
+        </Spinner>
+      </LoadingMask>
+    )
+  }
+
+  return <></>
+}
+
+export default Loading

--- a/src/components/PageWrapper.tsx
+++ b/src/components/PageWrapper.tsx
@@ -12,7 +12,9 @@ export const PageWrapper: React.FC = ({ children }) => {
       <div className={`theme-${theme || 'dark'}`}>
         <div className="page-base-container bg-theme-bg-main text-theme-text-main">
           <Header />
-          {children}
+          <div className="page-base-body">
+            {children}
+          </div>
           <Copyright />
         </div>
       </div>

--- a/src/contents/about/AboutPage.tsx
+++ b/src/contents/about/AboutPage.tsx
@@ -12,10 +12,9 @@ import { Status } from './Status/Status'
 const PageHeader = styled(Heading1)`
   font-size: ${Const.fontSize.xl2};
 `
-const renderLoader = () => <></>
 const Page: React.FC = () => {
   return (
-    <Suspense fallback={renderLoader()}>
+    <Suspense fallback={<></>}>
       <PageHeader>About</PageHeader>
       <About></About>
       <Classes></Classes>

--- a/src/contents/company/company.tsx
+++ b/src/contents/company/company.tsx
@@ -94,8 +94,6 @@ const Member: React.FC<MemberProps> = ({ member }) => {
   )
 }
 
-const renderLoader = () => <></>
-
 const Page: React.FC = () => {
   const members = [
     { imageUrl: CEO, color: 'red', title: 'CEO / 小池駿平', path: '/shunpei_koike' },
@@ -105,7 +103,7 @@ const Page: React.FC = () => {
   ]
 
   return (
-    <Suspense fallback={renderLoader()}>
+    <Suspense fallback={<></>}>
       <div className={styles.container}>
         <div
           style={{

--- a/src/contents/faq/FAQ.tsx
+++ b/src/contents/faq/FAQ.tsx
@@ -24,7 +24,6 @@ const GroupFAQ = styled.div`
     margin-bottom: 0px;
   }
 `
-const renderLoader = () => <></>
 export const Page: React.FC = (props) => {
   const faqs = [
     {
@@ -77,7 +76,7 @@ export const Page: React.FC = (props) => {
   ]
 
   return (
-    <Suspense fallback={renderLoader()}>
+    <Suspense fallback={<></>}>
       <div className={styles.pageWrapper}>
         <PageHeader>
           <TextDisplay>FAQ</TextDisplay>

--- a/src/contents/person/PersonPage.tsx
+++ b/src/contents/person/PersonPage.tsx
@@ -287,8 +287,6 @@ const ButtonEditWrapper = styled.div`
   align-items: center;
 `
 
-const renderLoader = () => <></>
-
 export const PersonPage: React.FC<PersonPageProps> = ({
   personal,
   editProfile,
@@ -301,7 +299,7 @@ export const PersonPage: React.FC<PersonPageProps> = ({
   const [selectedTeam, setSelectedTeam] = React.useState<IDisplayTeamMember | null>(null)
   const [showTeamLeaveModal, setShowTeamLeaveModal] = React.useState(false)
   return (
-    <Suspense fallback={renderLoader()}>
+    <Suspense fallback={<></>}>
       <ContentWrapper>
         <UserCoverWrapper>
           <UserCover backgroundColor={'#ebebeb'}>

--- a/src/contents/team/TeamLayout.tsx
+++ b/src/contents/team/TeamLayout.tsx
@@ -15,11 +15,9 @@ interface TeamLayoutProps {
   team: Team
 }
 
-const renderLoader = () => <></>
-
 const Layout: React.FC<TeamLayoutProps> = ({ team }) => {
   return (
-    <Suspense fallback={renderLoader()}>
+    <Suspense fallback={<></>}>
       <TeamTop image={team.topImage} />
       <TeamIntroduction
         name={team.name}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,15 +1,18 @@
-import * as React from 'react'
 import { Router } from '@reach/router'
-import { WithApolloProvider } from 'src/Apollo'
+import * as React from 'react'
+import { useApolloNetworkStatus, WithApolloProvider } from 'src/Apollo'
+import Loading from 'src/components/Loading'
 import { PageWrapper } from 'src/components/PageWrapper'
 import { ContentLayout } from 'src/contents/ContentLayout'
 import { ContentSubLayout } from 'src/contents/ContentSubLayout'
-import { ThemeContextProvider } from 'src/context/ThemeContext'
 import { Redirect } from 'src/contents/redirect'
+import { ThemeContextProvider } from 'src/context/ThemeContext'
 import { UserContextProvider } from 'src/context/UserContext'
 
 const IndexPage: React.FC = () => {
   const isSSR = typeof window === 'undefined'
+  const networkStatus = useApolloNetworkStatus();
+
   return (
     <>
       {!isSSR && (
@@ -29,6 +32,7 @@ const IndexPage: React.FC = () => {
               </PageWrapper>
             </UserContextProvider>
           </ThemeContextProvider>
+          <Loading loading={networkStatus.numPendingQueries > 0}></Loading>
         </React.Suspense>
       )}
     </>

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -102,6 +102,10 @@ body {
   background-color: $black;
 }
 
+.page-base-body {
+  min-height: calc(100vh - 110px);
+}
+
 ::-webkit-scrollbar-track {
   -webkit-box-shadow: inset 0 0 6px rgb(5, 16, 38);
   border-radius: 20px;

--- a/yarn.lock
+++ b/yarn.lock
@@ -18669,6 +18669,11 @@ rc@^1.2.7, rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-apollo-network-status@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-apollo-network-status/-/react-apollo-network-status-5.0.1.tgz#25a7ccf956e9c0dd2b7b7bab9efe2681ba0b841c"
+  integrity sha512-kA4WqEHUegc3IjvC9ZmA/hABRFpN9sjJ2wDehbRoyMyV2mVMoDcLq9BH/OQ6hpoeYZhTpl9F8np6fcWYERtn4g==
+
 react-circular-progressbar@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/react-circular-progressbar/-/react-circular-progressbar-2.0.3.tgz#fa8eb59f8db168d2904bae4590641792c80f5991"


### PR DESCRIPTION
# 内容

- react-apollo-network-status を依存関係に追加
- PendingになっているQueryがある場合にローディングマスクを表示

# 補足

- ページ遷移毎に表示される可能性があるため、ローディング画面は一般的なスピーナーにしています。
- Loadingに関するロジックが各所に現れるのを避けるため、グローバルにハンドルする方向で実装